### PR TITLE
Use regular python_debian now that it is no longer broken on python 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,7 @@ dev =
     testtools
 debian =
     debmutate
-    # Install from git until the fix for #1018822 makes it into pypi
-    python_debian@git+https://salsa.debian.org/python-debian-team/python-debian
+    python_debian
     python_apt@git+https://salsa.debian.org/apt-team/python-apt.git
     brz-debian
 remote =


### PR DESCRIPTION
Use regular python_debian now that it is no longer broken on python 3.8
