### PR TITLE
Depend on lz4 in debian for reading apt files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ debian =
     python_debian
     python_apt@git+https://salsa.debian.org/apt-team/python-apt.git
     brz-debian
+    lz4
 remote =
     breezy
     dulwich


### PR DESCRIPTION
Depend on lz4 in debian for reading apt files
