### PR TITLE
Fix Meson introspect to work with unconfigured projects

### DIFF
--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -137,7 +137,7 @@ mod tests {
     use super::*;
     use std::any::Any;
     use std::sync::Mutex;
-    
+
     // Global test lock to ensure tests using custom providers don't interfere with each other
     lazy_static! {
         static ref TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -171,7 +171,7 @@ mod tests {
     fn test_register_custom_provider() {
         // Acquire test lock to prevent interference from parallel tests
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         // Clear any existing providers from other tests
         clear_custom_providers();
 
@@ -216,7 +216,7 @@ mod tests {
     fn test_multiple_custom_providers() {
         // Acquire test lock to prevent interference from parallel tests
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         // Clear any existing providers from other tests
         clear_custom_providers();
 
@@ -269,7 +269,7 @@ mod tests {
     fn test_clear_custom_providers() {
         // Acquire test lock to prevent interference from parallel tests
         let _lock = TEST_LOCK.lock().unwrap();
-        
+
         clear_custom_providers();
 
         let test_dep = TestDependency {


### PR DESCRIPTION
The previous fix addressed working directory issues but meson introspect still failed on unconfigured projects with "Current directory is not a meson build directory" error. Meson introspect requires either a configured build directory or special handling for source directories.

This allows ognibuild to work with Meson projects in their source form without requiring pre-configuration, which is essential for build system detection and dependency analysis.