### PR TITLE
Fix Meson setup command to include source directory argument

### DIFF
--- a/src/buildsystems/meson.rs
+++ b/src/buildsystems/meson.rs
@@ -126,9 +126,10 @@ impl Meson {
         })?;
 
         // Set up the build directory
+        let project_dir_str = project_dir.to_string_lossy();
+        let temp_build_str = temp_build_dir.to_string_lossy();
         let setup_result = session
-            .command(vec!["meson", "setup", &temp_build_dir.to_string_lossy()])
-            .cwd(project_dir)
+            .command(vec!["meson", "setup", &project_dir_str, &temp_build_str])
             .quiet(true)
             .run_detecting_problems();
 


### PR DESCRIPTION
The previous fix for unconfigured project introspection was failing because the meson setup command was missing the source directory argument. The correct syntax is:

  meson setup <source_dir> <build_dir>

But the code was only passing the build directory:

  meson setup <build_dir>  # Wrong

Fixed by explicitly passing both the project directory (source) and the temporary build directory to the meson setup command. Also removed the .cwd() call since we now specify paths explicitly.