### PR TITLE
session: return an error instead of panicking when copying a project tree

### DIFF
--- a/src/session/schroot.rs
+++ b/src/session/schroot.rs
@@ -304,7 +304,12 @@ impl Session for SchrootSession {
         options.depth = 0; // Recursion depth (0 for unlimited depth)
 
         // Perform the copy operation
-        fs_extra::dir::copy(path, &export_directory, &options).unwrap();
+        fs_extra::dir::copy(path, &export_directory, &options).map_err(|e| {
+            Error::SetupFailure(
+                format!("failed to copy {} into session", path.display()),
+                e.to_string(),
+            )
+        })?;
 
         Ok(Project::Temporary {
             external_path: export_directory,

--- a/src/session/unshare.rs
+++ b/src/session/unshare.rs
@@ -594,7 +594,12 @@ impl Session for UnshareSession {
         options.depth = 0; // Recursion depth (0 for unlimited depth)
 
         // Perform the copy operation
-        fs_extra::dir::copy(path, &export_directory, &options).unwrap();
+        fs_extra::dir::copy(path, &export_directory, &options).map_err(|e| {
+            crate::session::Error::SetupFailure(
+                format!("failed to copy {} into session", path.display()),
+                e.to_string(),
+            )
+        })?;
 
         Ok(Project::Temporary {
             external_path: export_directory,


### PR DESCRIPTION
project_from_directory unwrapped the fs_extra copy, so a copy failure (e.g. a vanished source path) aborted the whole indexing run with a panic. Map the error onto SetupFailure so callers can handle it.