### PR TITLE
Fixed the gbp call site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 target
 *.so
 .claude/settings.local.json
+.vscode

--- a/src/debian/build.rs
+++ b/src/debian/build.rs
@@ -405,11 +405,14 @@ pub fn gbp_dch(path: &std::path::Path) -> Result<(), std::io::Error> {
         .arg("--ignore-branch")
         .current_dir(path)
         .output()?;
+
     if !cmd.status.success() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            "gbp-dch failed",
+            String::from_utf8(cmd.stderr).unwrap()
         ));
+    }else{
+        log::debug!("{}", String::from_utf8(cmd.stdout).unwrap())
     }
     Ok(())
 }
@@ -481,18 +484,10 @@ pub fn attempt_build(
             .abspath(std::path::Path::new(".git"))
             .map_or(false, |p| std::path::Path::new(&p).exists())
     {
-        match gbp_dch(&local_tree.abspath(subpath).unwrap()) {
-            Ok(_) => log::info!("successfully created orig tar using gbp"),
-            Err(e) => {
-                return Err(BuildOnceError::Unidentified {
-                    stage: None,
-                    phase: None,
-                    retcode: 1,
-                    command: vec!["gbp dch".to_string(), "--ignore-branch".to_string()],
-                    description: e.to_string(),
-                });
-            }
+        if let Err(e) = gbp_dch(&local_tree.abspath(subpath).unwrap()) {
+            log::error!("Failed to run gbp due to: {}", e);
         }
+            
     }
     if let Some(build_changelog_entry) = build_changelog_entry {
         assert!(

--- a/src/debian/build.rs
+++ b/src/debian/build.rs
@@ -392,15 +392,16 @@ fn get_last_changelog_entry(
     (e.package().unwrap(), e.version().unwrap())
 }
 
-/// Run gbp-dch to update the changelog.
+/// Run gbp dch to update the changelog.
 ///
 /// # Arguments
 /// * `path` - Path to the package directory
 ///
 /// # Returns
-/// Ok on success, Error if gbp-dch fails
+/// Ok on success, Error if gbp dch fails
 pub fn gbp_dch(path: &std::path::Path) -> Result<(), std::io::Error> {
-    let cmd = std::process::Command::new("gbp-dch")
+    let cmd = std::process::Command::new("gbp")
+        .arg("dch")
         .arg("--ignore-branch")
         .current_dir(path)
         .output()?;
@@ -480,7 +481,18 @@ pub fn attempt_build(
             .abspath(std::path::Path::new(".git"))
             .map_or(false, |p| std::path::Path::new(&p).exists())
     {
-        gbp_dch(&local_tree.abspath(subpath).unwrap()).unwrap();
+        match gbp_dch(&local_tree.abspath(subpath).unwrap()) {
+            Ok(_) => log::info!("successfully created orig tar using gbp"),
+            Err(e) => {
+                return Err(BuildOnceError::Unidentified {
+                    stage: None,
+                    phase: None,
+                    retcode: 1,
+                    command: vec!["gbp dch".to_string(), "--ignore-branch".to_string()],
+                    description: e.to_string(),
+                });
+            }
+        }
     }
     if let Some(build_changelog_entry) = build_changelog_entry {
         assert!(

--- a/src/debian/build.rs
+++ b/src/debian/build.rs
@@ -407,12 +407,16 @@ pub fn gbp_dch(path: &std::path::Path) -> Result<(), std::io::Error> {
         .output()?;
 
     if !cmd.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            String::from_utf8(cmd.stderr).unwrap()
-        ));
-    }else{
-        log::debug!("{}", String::from_utf8(cmd.stdout).unwrap())
+        if cmd.stderr.len() > 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                String::from_utf8(cmd.stderr).unwrap(),
+            ));
+        } else {
+            log::debug!(
+                "gbp:error: Either 'EMAIL' or 'DEBEMAIL' must be set in the environment for 'dch' to work"
+            );
+        }
     }
     Ok(())
 }
@@ -487,7 +491,6 @@ pub fn attempt_build(
         if let Err(e) = gbp_dch(&local_tree.abspath(subpath).unwrap()) {
             log::error!("Failed to run gbp due to: {}", e);
         }
-            
     }
     if let Some(build_changelog_entry) = build_changelog_entry {
         assert!(

--- a/src/debian/build.rs
+++ b/src/debian/build.rs
@@ -407,16 +407,10 @@ pub fn gbp_dch(path: &std::path::Path) -> Result<(), std::io::Error> {
         .output()?;
 
     if !cmd.status.success() {
-        if cmd.stderr.len() > 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                String::from_utf8(cmd.stderr).unwrap(),
-            ));
-        } else {
-            log::debug!(
-                "gbp:error: Either 'EMAIL' or 'DEBEMAIL' must be set in the environment for 'dch' to work"
-            );
-        }
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            String::from_utf8(cmd.stderr).unwrap(),
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
This is still a work in progress. It's still erroring out, 
```
N: Some sources can be modernized. Run 'apt modernize-sources' to do so.
Hit:1 http://deb.debian.org/debian sid InRelease
All packages are up to date.    
Notice: Some sources can be modernized. Run 'apt modernize-sources' to do so.
Building dependencies in /home/anurag/.cache/debianize/
/usr/lib/python3/dist-packages/breezy/plugins/debian/apt_repo.py:98: Warning: W:Unable to read /tmp/.tmp5Kabdo/etc/apt/apt.conf.d/ - DirectoryExists (2: No such file or directory)
  self.apt_pkg.init()
Using fixers: [PgBuildExtOutOfDateControlFixer, MissingConfigureFixer, MissingAutomakeInputFixer, MissingConfigStatusInputFixer, MissingPerlFileFixer, DebcargoUnacceptablePredicateFixer, DebcargoUnacceptableComparatorFixer, RetryAptFetchFailure, PackageDependencyFixer]
Build failed with unidentified error. Giving up.
Error: 
```
This is done assuming we're not opting for the fast build: https://github.com/jelmer/ognibuild/blob/main/src/session/unshare.rs#L167

As this step error due to some permission issues, 
```
thread 'main' (63622) panicked at debianize/src/main.rs:583:82:
called `Result::unwrap()` on an `Err` value: SetupFailure("Failed to create /dev/shm", "Permission denied (os error 13)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```