### PR TITLE
plain session: don't panic on paths that don't exist

### DIFF
--- a/src/actions/lsif.rs
+++ b/src/actions/lsif.rs
@@ -214,18 +214,8 @@ pub fn run_lsif(
             }
             Output::Stdout => {
                 // The indexer streams the dump to stdout; redirect that straight
-                // into the output file. `external_path` canonicalizes its
-                // argument, so resolve the (existing) parent directory and join
-                // the file name rather than the not-yet-created file.
-                let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
-                let dir = session.external_path(parent.unwrap_or(Path::new(".")));
-                let file_name = output.file_name().ok_or_else(|| {
-                    Error::Other(format!(
-                        "Output path has no file name: {}",
-                        output.display()
-                    ))
-                })?;
-                let file = std::fs::File::create(dir.join(file_name))?;
+                // into the output file.
+                let file = std::fs::File::create(session.external_path(output))?;
                 let status = session
                     .command(argv)
                     .stdout(std::process::Stdio::from(file))

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -198,6 +198,9 @@ pub trait Session {
     fn pwd(&self) -> &std::path::Path;
 
     /// Return the external path for a path inside the session.
+    ///
+    /// The path need not exist; callers may use this to find out where to
+    /// create a file.
     fn external_path(&self, path: &std::path::Path) -> std::path::PathBuf;
 
     /// Return the location of the session.

--- a/src/session/plain.rs
+++ b/src/session/plain.rs
@@ -12,6 +12,31 @@ impl Default for PlainSession {
     }
 }
 
+/// Canonicalize the longest existing ancestor of `path` and re-append the rest.
+///
+/// `std::fs::canonicalize` fails when the path does not exist, but callers
+/// legitimately ask for the external path of a file they are about to create.
+/// Symlinks and `..` in the existing part are still resolved.
+fn canonicalize_existing_prefix(path: &std::path::Path) -> std::path::PathBuf {
+    let mut suffix: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut prefix = path;
+
+    loop {
+        if let Ok(canonical) = prefix.canonicalize() {
+            return canonical.join(suffix.iter().rev().collect::<std::path::PathBuf>());
+        }
+        match (prefix.parent(), prefix.file_name()) {
+            (Some(parent), Some(name)) => {
+                suffix.push(name);
+                prefix = parent;
+            }
+            // Reached the root without finding anything that exists; there is
+            // nothing left to resolve.
+            _ => return path.to_path_buf(),
+        }
+    }
+}
+
 impl PlainSession {
     /// Create a new PlainSession.
     ///
@@ -59,7 +84,7 @@ impl Session for PlainSession {
     }
 
     fn chdir(&mut self, path: &std::path::Path) -> Result<(), Error> {
-        self.0 = self.0.join(path).canonicalize().unwrap();
+        self.0 = self.0.join(path).canonicalize().map_err(Error::IoError)?;
         Ok(())
     }
 
@@ -68,7 +93,7 @@ impl Session for PlainSession {
     }
 
     fn external_path(&self, path: &std::path::Path) -> std::path::PathBuf {
-        self.0.join(path).canonicalize().unwrap()
+        canonicalize_existing_prefix(&self.0.join(path))
     }
 
     fn check_output(
@@ -321,6 +346,20 @@ mod tests {
     }
 
     #[test]
+    fn test_chdir_nonexistent() {
+        let mut session = PlainSession::new();
+        let td = tempfile::tempdir().unwrap();
+        let path = td.path().join("does-not-exist");
+        match session.chdir(&path) {
+            Err(Error::IoError(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected IoError, got {:?}", other),
+        }
+        assert_eq!(session.pwd(), std::path::Path::new("/"));
+    }
+
+    #[test]
     fn test_pwd() {
         let mut session = PlainSession::new();
         let pwd = session.pwd();
@@ -338,6 +377,36 @@ mod tests {
         let path = td.path().join("test");
         session.mkdir(&path).unwrap();
         assert_eq!(session.external_path(&path), path.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_external_path_nonexistent() {
+        let session = PlainSession::new();
+        let td = tempfile::tempdir().unwrap();
+        let path = td.path().join("does-not-exist").join("config.toml");
+        assert_eq!(
+            session.external_path(&path),
+            td.path()
+                .canonicalize()
+                .unwrap()
+                .join("does-not-exist")
+                .join("config.toml")
+        );
+    }
+
+    #[test]
+    fn test_external_path_relative_to_cwd() {
+        let mut session = PlainSession::new();
+        let td = tempfile::tempdir().unwrap();
+        session.chdir(td.path()).unwrap();
+        assert_eq!(
+            session.external_path(std::path::Path::new("sub/new-file")),
+            td.path()
+                .canonicalize()
+                .unwrap()
+                .join("sub")
+                .join("new-file")
+        );
     }
 
     #[test]


### PR DESCRIPTION
PlainSession::external_path canonicalized its argument, which fails for a file the caller is about to create. Canonicalize the longest existing ancestor instead and re-append the rest, matching what the schroot and unshare sessions already do. chdir now returns the IO error rather than unwrapping it.